### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/renderer/src/utils/downloadUtils.js
+++ b/src/renderer/src/utils/downloadUtils.js
@@ -101,7 +101,7 @@ export const objectToCsv = (array) => {
   for (const obj of array) {
     const values = headers.map((header) => {
       const value = obj[header] !== undefined ? obj[header] : ''
-      const escapedValue = ('' + value).replace(/"/g, '\\"')
+      const escapedValue = ('' + value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')
       return `"${escapedValue}"`
     })
     csvRows.push(values.join(','))


### PR DESCRIPTION
Fixes [https://github.com/worldbank/DHIS2-Downloader/security/code-scanning/2](https://github.com/worldbank/DHIS2-Downloader/security/code-scanning/2)

To fix the problem, we need to ensure that both double quotes and backslashes are properly escaped in the CSV output. This can be achieved by first escaping backslashes and then escaping double quotes. The order of escaping is important to avoid double-escaping backslashes.

The best way to fix this is to update the `objectToCsv` function to use a regular expression that handles both backslashes and double quotes. We will replace the current `replace` call with a more comprehensive one that escapes both characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
