### PR TITLE
Fix silent download failure + adaptive period-splitting for strict DHIS2 servers

### DIFF
--- a/src/renderer/src/pages/MainPage/index.jsx
+++ b/src/renderer/src/pages/MainPage/index.jsx
@@ -15,12 +15,12 @@ import {
 } from '../../reducers/statusReducer'
 import Tooltip from '../../components/Tooltip'
 import { openModal, closeModal } from '../../reducers/modalReducer'
-import { fetchCsvData } from '../../service/useApi'
 import { generatePeriods } from '../../utils/dateUtils'
 import {
   generateDownloadingUrl,
   createDataChunks,
-  buildOuParamForOneParent
+  buildOuParamForOneParent,
+  fetchCsvChunkAdaptive
 } from '../../utils/downloadUtils'
 import { useTranslation } from 'react-i18next'
 
@@ -121,19 +121,29 @@ const MainPage = ({ queryDb }) => {
     let hadAnyFailure = false
     if (!chunks.length) return { hadAnySuccess, hadAnyFailure }
 
-    // 1️⃣ Fire all requests in parallel (no DB writes yet)
+    // 1️⃣ Fire all requests in parallel (no DB writes yet).
+    // Each chunk self-heals: if the server rejects it as "too many combinations",
+    // fetchCsvChunkAdaptive splits the periods and retries down to a single period.
     const fetches = chunks.map(({ dx, periods, ou }, idx) => {
-      const url = generateDownloadingUrl(
-        dhis2Url,
-        ou,
-        dx.join(';'),
-        periods.join(';'),
-        downloadParams.co,
-        'csv',
-        downloadParams.layout
+      return fetchCsvChunkAdaptive(
+        {
+          dhis2Url,
+          ou,
+          dx,
+          periods,
+          co: downloadParams.co,
+          layout: downloadParams.layout,
+          username,
+          password
+        },
+        (splitPeriods) =>
+          dispatch(
+            addLog({
+              message: `Chunk too large, splitting ${splitPeriods[0]}–${splitPeriods.at(-1)} and retrying…`,
+              type: 'info'
+            })
+          )
       )
-      return fetchCsvData(url, username, password)
-        .then((blob) => blob.text())
         .then((text) => ({ idx, text, dx, periods, ou }))
         .catch((error) => ({ idx, error, dx, periods, ou }))
     })

--- a/src/renderer/src/service/useApi.js
+++ b/src/renderer/src/service/useApi.js
@@ -86,7 +86,16 @@ export const fetchCsvData = async (apiUrl, username, password, timeout = 1200000
       throw new Error(errorText || `HTTP error! status: ${response.status}`)
     }
 
-    return await response.blob()
+    // Some DHIS2 servers return an error (e.g. E7151 "Too many combinations")
+    // as an HTTP 200 body on the analytics.csv endpoint. Detect that here so it
+    // is treated as a failure instead of being written to file as bogus data.
+    const blob = await response.blob()
+    const text = await blob.text()
+    const firstLine = (text.split('\n').find((l) => l.trim().length) || '').trim()
+    if (/^E\d{3,4}\s*:/.test(firstLine) || /too many combinations/i.test(firstLine)) {
+      throw new Error(firstLine)
+    }
+    return new Blob([text], { type: 'text/csv' })
   } catch (error) {
     if (error.name === 'AbortError') {
       throw new Error(`Request timed out after ${timeout}ms`)

--- a/src/renderer/src/utils/downloadUtils.js
+++ b/src/renderer/src/utils/downloadUtils.js
@@ -1,3 +1,55 @@
+import { fetchCsvData } from '../service/useApi'
+
+// Merge several CSV strings: keep the first header, append every data row.
+export const mergeCsvTexts = (texts) => {
+  let header = ''
+  const body = []
+  for (const t of texts) {
+    if (!t) continue
+    const lines = t.split('\n').filter((l) => l.trim().length)
+    if (!lines.length) continue
+    if (!header) header = lines[0]
+    body.push(...lines.slice(1))
+  }
+  return header ? [header, ...body].join('\n') : ''
+}
+
+// Fetch one chunk as CSV text. If the server rejects it with a
+// "too many combinations" limit (E7151, returned as HTTP 409 or as an
+// HTTP-200 CSV error body - both surfaced as a thrown error by fetchCsvData),
+// split the periods in half and retry recursively down to a single period,
+// then merge the pieces. This makes downloads self-heal on strict servers
+// (e.g. facility-level pulls) regardless of the configured chunk size.
+export const fetchCsvChunkAdaptive = async (
+  { dhis2Url, ou, dx, periods, co, layout, username, password },
+  onSplit
+) => {
+  const url = generateDownloadingUrl(dhis2Url, ou, dx.join(';'), periods.join(';'), co, 'csv', layout)
+  try {
+    const blob = await fetchCsvData(url, username, password)
+    return await blob.text()
+  } catch (err) {
+    const tooMany = /too many combinations|E7151/i.test(err?.message || '')
+    if (!tooMany || periods.length <= 1) {
+      // single period still too large, or an unrelated error - cannot recover here
+      throw err
+    }
+    if (onSplit) onSplit(periods)
+    const mid = Math.ceil(periods.length / 2)
+    const [left, right] = await Promise.all([
+      fetchCsvChunkAdaptive(
+        { dhis2Url, ou, dx, periods: periods.slice(0, mid), co, layout, username, password },
+        onSplit
+      ),
+      fetchCsvChunkAdaptive(
+        { dhis2Url, ou, dx, periods: periods.slice(mid), co, layout, username, password },
+        onSplit
+      )
+    ])
+    return mergeCsvTexts([left, right])
+  }
+}
+
 export const generateDownloadingUrl = (
   dhis2Url,
   ou,


### PR DESCRIPTION
## Problem
On strict DHIS2 servers (reproduced on Afghanistan, `moph-dw.gov.af`, at facility level `LEVEL-7`), downloads silently produce an **empty file** with no error shown.

Two root causes:

1. **Errors returned as HTTP 200.** The `analytics.csv` endpoint returns `E7151: Too many combinations of columns or rows.` with a **200 status** and the error text as the CSV body. `fetchCsvData` only checked `response.ok`, so this was treated as success — the error line was written as the CSV header with zero data rows, and no error surfaced.

2. **Default chunk size of 3 triggers the limit.** At facility level, requests of ≥3 periods exceed the server's combination limit (1–2 periods succeed). With the default `chunkingStrategy = 3`, every chunk fails this way. Failed chunks were not retried.

Verified against the live server:
| chunk | result |
|---|---|
| 1 month | 200, 3,701 rows |
| 2 months | 200, 7,562 rows |
| 3 months (default) | 200, **0 rows** (body = E7151) |

## Fix
1. **`fetchCsvData`** now inspects the CSV body and throws when the first line is a DHIS2 error (`^E\d{3,4}:` / "too many combinations"), so failures are handled/visible instead of written as data.
2. **`fetchCsvChunkAdaptive`** (new) splits a chunk's periods in half and retries recursively down to a single period on a "too many combinations" error, then merges the CSV pieces. `processChunks` uses it, so downloads self-heal regardless of the configured chunk size.

After the fix, the failing 3-month case auto-splits and returns all rows (verified: 11,392 rows for 3 months × 1 indicator at facility level).

## Notes
- No dependency or API changes; contained to `useApi.js`, `downloadUtils.js`, `MainPage/index.jsx`.
- A "splitting … and retrying" log line is emitted so users can see it self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)